### PR TITLE
Use URI.open for Ruby 3.0

### DIFF
--- a/lib/omniauth/cloudiap/iapjwt.rb
+++ b/lib/omniauth/cloudiap/iapjwt.rb
@@ -24,7 +24,7 @@ module OmniAuth
       def jwk_keys
         @jwk_keys ||= begin
           url = "https://www.gstatic.com/iap/verify/public_key-jwk"
-          open(url) { |f| JSON.parse(f.read) }
+          URI.open(url) { |f| JSON.parse(f.read) }
         end
       end
 


### PR DESCRIPTION
`Kernel.#open` is deprecated in Ruby 2.7 and removed in Ruby 3.0.
Use `URI.open` to support Ruby 3.0.

Ref: https://github.com/ruby/open-uri/commit/53862fa35887a34a8060aebf2241874240c2986a